### PR TITLE
Validate PK nullability and FK domain match (issue #6)

### DIFF
--- a/modelith-spec.md
+++ b/modelith-spec.md
@@ -190,6 +190,8 @@ columns:
 
 `mdl validate` runs, in order: schema validation, referential integrity of ULIDs, naming standard lint, ontology alignment check (Section 3), pattern conformance, and semantic joinability (Section 6). Exit codes must distinguish error from warning so CI can gate on severity.
 
+**Key and foreign-key integrity** (issue #6). Primary and foreign keys are modelled structurally — a primary key is a `pk` KeyGroup with ordered `members` (composite-capable), a foreign key is a `Relationship` whose `from`/`to` ends carry paired attribute lists (multi-column-capable) — not as a per-attribute `role`. The validator enforces: at most one `pk` KeyGroup per entity (MDL-E108), members belong to their entity (MDL-E106), a warning when a PK member is `nullable: true` (MDL-W115), and an error when a foreign key's paired attributes have mismatched domains (MDL-E114). This is deliberately *not* a `role: primary_key`/`foreign_key` + `references:` attribute syntax: that would be a second, weaker source of truth for the same fact and could not express composite keys or multi-column FKs cleanly.
+
 **Naming standards are a first-class, enforceable config**, not documentation. erwin has this and every open-source competitor skips it. Support abbreviation dictionaries, casing rules per layer, prefix/suffix rules per pattern, and a `--fix` mode.
 
 ---

--- a/packages/core/src/mdl_core/validate.py
+++ b/packages/core/src/mdl_core/validate.py
@@ -26,6 +26,7 @@ def validate(model: Model) -> DiagnosticSet:
     diags = DiagnosticSet()
     _check_referential_integrity(model, diags)
     _check_key_groups(model, diags)
+    _check_relationship_domains(model, diags)
     _check_subject_areas(model, diags)
     _check_categories(model, diags)
     _check_ontology_layers(model, diags)
@@ -285,6 +286,26 @@ def _check_key_groups(model: Model, diags: DiagnosticSet) -> None:
             )
         if kg.type == "pk":
             pk_count[kg.entity] = pk_count.get(kg.entity, 0) + 1
+            # A primary key identifies the row, so every PK column must be non-null.
+            # A nullable PK member is almost always an oversight (issue #6): warn
+            # rather than error, since the legacy `role: business_key` convention did
+            # not carry a nullability contract and we do not want to break old models.
+            attr_by_id = {a.id: a for a in le.attributes}
+            for m in kg.members:
+                a = attr_by_id.get(m)
+                if a is not None and a.nullable:
+                    diags.add(
+                        Diagnostic(
+                            code="MDL-W115",
+                            severity=Severity.warning,
+                            message=(
+                                f"primary-key attribute {a.name!r} of entity "
+                                f"{le.name!r} is nullable; a primary key must not be "
+                                f"null — set nullable: false"
+                            ),
+                            path=a.id,
+                        )
+                    )
 
     for entity_id, n in pk_count.items():
         if n > 1:
@@ -297,6 +318,55 @@ def _check_key_groups(model: Model, diags: DiagnosticSet) -> None:
                     path=entity_id,
                 )
             )
+
+
+def _attr_by_id(model: Model):
+    """ULID -> (Attribute, owning LogicalEntity) across the whole model, for
+    cross-entity attribute lookups (a relationship's ends live on two entities)."""
+    out = {}
+    for le in model.logical_entities.values():
+        for a in le.attributes:
+            out[a.id] = (a, le)
+    return out
+
+
+def _check_relationship_domains(model: Model, diags: DiagnosticSet) -> None:
+    """A foreign key must be type-compatible with what it references (issue #6): the
+    from-side and to-side attributes are paired positionally, and each pair must share
+    a domain. A mismatch means a join that will never work — an error, not a warning.
+
+    Only fires for pairs where BOTH attributes resolve and BOTH declare a domain;
+    missing attributes are already reported by the referential check (MDL-E103), and
+    an absent domain is a separate concern."""
+    idx = _attr_by_id(model)
+    for rel in model.relationships.values():
+        fa, ta = rel.from_.attributes, rel.to.attributes
+        # Only compare when the two ends are explicitly column-mapped 1:1. An
+        # unmapped or ragged end is a modelling choice, not a type error.
+        if not fa or not ta or len(fa) != len(ta):
+            continue
+        for fid, tid in zip(fa, ta, strict=True):  # equal length checked above
+            fe, te = idx.get(fid), idx.get(tid)
+            if fe is None or te is None:
+                continue  # MDL-E103 handles a dangling attribute ref
+            fattr, fent = fe
+            tattr, tent = te
+            if fattr.domain is None or tattr.domain is None:
+                continue
+            if fattr.domain != tattr.domain:
+                diags.add(
+                    Diagnostic(
+                        code="MDL-E114",
+                        severity=Severity.error,
+                        message=(
+                            f"foreign key {rel.name!r}: {fent.name}.{fattr.name} "
+                            f"(domain {fattr.domain!r}) references "
+                            f"{tent.name}.{tattr.name} (domain {tattr.domain!r}) — "
+                            f"the domains must match"
+                        ),
+                        path=rel.id,
+                    )
+                )
 
 
 def _check_categories(model: Model, diags: DiagnosticSet) -> None:

--- a/packages/core/tests/test_key_constraints.py
+++ b/packages/core/tests/test_key_constraints.py
@@ -1,0 +1,160 @@
+"""PK-nullability warning (MDL-W115) and FK domain-match error (MDL-E114) — issue #6.
+
+Modelith already models primary keys as `pk` KeyGroups and foreign keys as
+Relationships (from/to ends with paired attribute lists). These two checks close the
+validation gaps the issue asked for, on that existing model."""
+
+from __future__ import annotations
+
+from mdl_core.ir import (
+    Attribute,
+    Domain,
+    KeyGroup,
+    LogicalEntity,
+    Model,
+    ProjectConfig,
+    Relationship,
+    RelationshipEnd,
+)
+from mdl_core.validate import validate
+
+
+def _codes(m, severity):
+    return sorted({d.code for d in validate(m).items if d.severity.value == severity})
+
+
+# --- MDL-W115: a primary-key column must not be nullable --------------------------
+
+
+def test_nullable_pk_member_warns():
+    m = Model(ProjectConfig(name="x"))
+    m.add(
+        LogicalEntity(
+            id="01LE",
+            name="cust",
+            attributes=[Attribute(id="01A1", name="cust_id", nullable=True)],
+        )
+    )
+    m.add(KeyGroup(id="01KG", entity="01LE", name="pk", type="pk", members=["01A1"]))
+    warns = _codes(m, "warning")
+    assert "MDL-W115" in warns
+    # it is a warning, not an error — legacy models must not suddenly fail
+    assert "MDL-W115" not in _codes(m, "error")
+
+
+def test_non_nullable_pk_member_is_clean():
+    m = Model(ProjectConfig(name="x"))
+    m.add(
+        LogicalEntity(
+            id="01LE",
+            name="cust",
+            attributes=[Attribute(id="01A1", name="cust_id", nullable=False)],
+        )
+    )
+    m.add(KeyGroup(id="01KG", entity="01LE", name="pk", type="pk", members=["01A1"]))
+    assert "MDL-W115" not in _codes(m, "warning")
+
+
+def test_nullable_non_pk_key_does_not_warn():
+    """Only PK members carry the non-null contract; an alternate/unique key may be
+    nullable (a nullable unique column is legal SQL)."""
+    m = Model(ProjectConfig(name="x"))
+    m.add(
+        LogicalEntity(
+            id="01LE",
+            name="cust",
+            attributes=[
+                Attribute(id="01A1", name="cust_id", nullable=False),
+                Attribute(id="01A2", name="email", nullable=True),
+            ],
+        )
+    )
+    m.add(KeyGroup(id="01KG1", entity="01LE", name="pk", type="pk", members=["01A1"]))
+    m.add(KeyGroup(id="01KG2", entity="01LE", name="uq_email", type="unique", members=["01A2"]))
+    assert "MDL-W115" not in _codes(m, "warning")
+
+
+def test_composite_pk_flags_only_the_nullable_member():
+    m = Model(ProjectConfig(name="x"))
+    m.add(
+        LogicalEntity(
+            id="01LE",
+            name="line",
+            attributes=[
+                Attribute(id="01A1", name="order_id", nullable=False),
+                Attribute(id="01A2", name="line_no", nullable=True),
+            ],
+        )
+    )
+    m.add(KeyGroup(id="01KG", entity="01LE", name="pk", type="pk", members=["01A1", "01A2"]))
+    diags = [d for d in validate(m).items if d.code == "MDL-W115"]
+    assert len(diags) == 1
+    assert diags[0].path == "01A2"  # only the nullable member
+
+
+# --- MDL-E114: a foreign key must be domain-compatible with its target ------------
+
+
+def _fk_model(from_domain, to_domain):
+    m = Model(ProjectConfig(name="x"))
+    m.add(Domain(id="01D1", name="integer", base_type="integer"))
+    m.add(Domain(id="01D2", name="text", base_type="string"))
+    m.add(
+        LogicalEntity(
+            id="01ADDR",
+            name="address",
+            attributes=[Attribute(id="01AID", name="address_id", domain=to_domain, nullable=False)],
+        )
+    )
+    m.add(
+        LogicalEntity(
+            id="01CUST",
+            name="customer",
+            attributes=[
+                Attribute(id="01CID", name="customer_id", domain="integer", nullable=False),
+                Attribute(id="01FK", name="address_id", domain=from_domain, nullable=True),
+            ],
+        )
+    )
+    m.add(
+        Relationship(
+            id="01REL",
+            name="customer_address",
+            **{"from": RelationshipEnd(entity="01CUST", attributes=["01FK"])},
+            to=RelationshipEnd(entity="01ADDR", attributes=["01AID"]),
+        )
+    )
+    return m
+
+
+def test_fk_domain_match_is_clean():
+    assert "MDL-E114" not in _codes(_fk_model("integer", "integer"), "error")
+
+
+def test_fk_domain_mismatch_errors():
+    codes = _codes(_fk_model("text", "integer"), "error")
+    assert "MDL-E114" in codes
+
+
+def test_fk_with_missing_domain_is_not_flagged():
+    """An absent domain on either side is a different concern; the FK check only
+    compares when both sides declare one."""
+    assert "MDL-E114" not in _codes(_fk_model(None, "integer"), "error")
+
+
+def test_fk_with_no_attribute_mapping_is_not_flagged():
+    """A relationship whose ends are not column-mapped is a modelling choice, not a
+    type error — nothing to compare."""
+    m = Model(ProjectConfig(name="x"))
+    m.add(Domain(id="01D1", name="integer", base_type="integer"))
+    m.add(LogicalEntity(id="01A", name="a", attributes=[Attribute(id="01AA", name="x", domain="integer")]))
+    m.add(LogicalEntity(id="01B", name="b", attributes=[Attribute(id="01BB", name="y", domain="integer")]))
+    m.add(
+        Relationship(
+            id="01REL",
+            name="a_b",
+            **{"from": RelationshipEnd(entity="01A", attributes=[])},
+            to=RelationshipEnd(entity="01B", attributes=[]),
+        )
+    )
+    assert "MDL-E114" not in _codes(m, "error")


### PR DESCRIPTION
Primary and foreign keys are already first-class in Modelith — a PK is a `pk` KeyGroup with ordered members (composite-capable), an FK is a Relationship whose from/to ends carry paired attribute lists (multi-column-capable). This closes the two validation gaps that model left open:

- MDL-W115 (warning): a PK KeyGroup member marked `nullable: true` — a primary key must not be null. A warning, not an error, so legacy models built on the `role: business_key` convention (which carried no nullability contract) don't suddenly fail.
- MDL-E114 (error): a foreign key whose paired from/to attributes have mismatched domains — a join that can never work. Only compares when both ends are column-mapped 1:1 and both declare a domain.

Deliberately NOT adding a `role: primary_key`/`foreign_key` + `references:` attribute syntax (as the issue proposed): it would be a second, weaker source of truth for the same fact and couldn't express composite keys or multi-column FKs cleanly. The existing KeyGroup/Relationship model already covers the issue's desired effects (validation, dbt constraints/tests, ERD cardinality).

Tests: test_key_constraints.py (nullable/composite PK, FK match/mismatch/missing- domain/unmapped). 561 passed, 1 skipped; ruff clean; verified on the CLI. Spec §2.4 documents the codes and the design rationale.

<!-- Thanks for contributing to Modelith. Keep this short. -->

## What this changes

<!-- One or two sentences on what and why. Link the issue it closes: Closes #123 -->

## How it was tested

<!-- The commands you ran. `uv run pytest` and `uv run ruff check packages/` at minimum. -->

## Checklist

- [ ] Tests pass locally (`uv run pytest`)
- [ ] Lint passes (`uv run ruff check packages/`)
- [ ] Docs or the README updated if behavior changed
- [ ] The change fits the git-native, stateless design (git stays the source of truth)
