### PR TITLE
Release 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # project, so the install name is `modelith-dbt` (install: uv tool install
 # modelith-dbt). The command stays `mdl`; the import modules stay mdl_*.
 name = "modelith-dbt"
-version = "0.1.2"
+version = "0.2.0"
 description = "Ontology-anchored, git-native data modeling tool for dbt-core teams"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -724,7 +724,7 @@ requires-dist = [
 
 [[package]]
 name = "modelith-dbt"
-version = "0.1.2"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "dbt-artifacts-parser" },


### PR DESCRIPTION
Bumping modelith-dbt to 0.2.0 for the feature release since 0.1.1: 

- IdP-agnostic identity + write gate + OpenTelemetry audit log for shared/enterprise servers; 
- staged-diff Review and staged route classification; attribute-level ERD relationships; 
- primary-key nullability and foreign-key domain validation; 
- commands that run from anywhere inside a model; and
- Model-tab import/export (SQL DDL, Mermaid, DBML, CSV, ODCS, Cypher export; SQL DDL / Mermaid / JSON Schema import) via the new mdl_emit_erd package. Adds sqlglot as a dependency.

