### PR TITLE
Surface drift in VS Code and chat (core drift spec)

### DIFF
--- a/packages/cli/src/mdl_cli/main.py
+++ b/packages/cli/src/mdl_cli/main.py
@@ -556,6 +556,13 @@ def drift(
     reconcile_: bool = typer.Option(
         False, "--reconcile", help="Apply additive/cosmetic deltas to the model"
     ),
+    explain: bool = typer.Option(
+        False,
+        "--explain",
+        help="Annotate each item with its reconcile action (safe vs human-gated). "
+        "With --format json emits the structured shape the AI surfaces consume; "
+        "otherwise a deterministic narrative.",
+    ),
     fmt: str = typer.Option("text", "--format", help="text|json|mermaid"),
 ) -> None:
     """Compare the committed model to a compiled dbt manifest (spec §5.4)."""
@@ -587,7 +594,24 @@ def drift(
             )
         )
 
-    if fmt == "json":
+    if explain:
+        # The explained shape carries, per item, whether --reconcile would fold it,
+        # the concrete action, and the owning YAML file — the single structure the
+        # CLI, MCP tool and VS Code drift UI all consume (mdl_reverse.explain).
+        from mdl_reverse.explain import explain_report, render_explain_text
+        from mdl_reverse.reconcile import model_name_to_ulid
+
+        name_to_le = model_name_to_ulid(repo, tgt)
+
+        def _file_for(model_name: str) -> str | None:
+            le_id = name_to_le.get(model_name)
+            return repo.path_for_ulid(le_id) if le_id else None
+
+        if fmt == "json":
+            typer.echo(json.dumps(explain_report(report, _file_for), indent=2, sort_keys=True))
+        else:
+            typer.echo(render_explain_text(report))
+    elif fmt == "json":
         typer.echo(render_json(report))
     elif fmt == "mermaid":
         typer.echo(render_markdown(report))

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -7,6 +7,7 @@ license = { text = "Apache-2.0" }
 dependencies = [
     "modelith-core",
     "modelith-ontology",
+    "modelith-reverse",
     # v1 FastMCP API. mcp 2.x renamed FastMCP -> MCPServer and is still very new;
     # editor MCP clients (VS Code, Claude Desktop, Cursor) target the v1 stdio
     # server today, so pin below 2 until the ecosystem moves.
@@ -23,3 +24,4 @@ packages = ["src/mdl_mcp"]
 [tool.uv.sources]
 modelith-core = { workspace = true }
 modelith-ontology = { workspace = true }
+modelith-reverse = { workspace = true }

--- a/packages/mcp/src/mdl_mcp/server.py
+++ b/packages/mcp/src/mdl_mcp/server.py
@@ -109,6 +109,41 @@ def build_server(repo_dir: Path) -> FastMCP:
             }
         )
 
+    @mcp.tool()
+    def explain_drift(manifest: str | None = None, target: str | None = None) -> str:
+        """Compare the committed model to a compiled dbt manifest and return the drift,
+        annotated per item with whether it is safely reconcilable and the concrete
+        action. Severity (breaking / additive / cosmetic) is authoritative — it comes
+        from the engine, not from you; never re-derive it. Breaking items are never
+        auto-reconcilable and need a human decision.
+
+        `manifest` defaults to <repo>/target/manifest.json; `target` defaults to the
+        project's dbt_target. Returns an error object if no manifest is found."""
+        from mdl_reverse.drift import compute_drift
+        from mdl_reverse.explain import explain_report
+        from mdl_reverse.manifest import read_manifest
+        from mdl_reverse.reconcile import model_name_to_ulid
+
+        repo = ModelRepo.load(repo_dir)
+        tgt = target or repo.model.config.dbt_target or "duckdb_dev"
+        man_path = Path(manifest) if manifest else repo_dir / "target" / "manifest.json"
+        if not man_path.is_absolute():
+            man_path = repo_dir / man_path
+        try:
+            proj = read_manifest(man_path)
+        except FileNotFoundError:
+            return _json(
+                {"error": f"no dbt manifest at {man_path} — run `dbt compile` first"}
+            )
+        report = compute_drift(repo.model, proj, tgt)
+        name_to_le = model_name_to_ulid(repo, tgt)
+
+        def _file_for(model_name: str) -> str | None:
+            le_id = name_to_le.get(model_name)
+            return repo.path_for_ulid(le_id) if le_id else None
+
+        return _json(explain_report(report, _file_for))
+
     # --- writes (validated + fingerprint-guarded via apply_command) -------------
 
     @mcp.tool()

--- a/packages/mcp/tests/test_server.py
+++ b/packages/mcp/tests/test_server.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from pathlib import Path
 
 from mdl_mcp.server import build_server
 
@@ -35,6 +36,7 @@ def test_tools_are_registered(model_dir):
         "get_model_context",
         "search_ontology",
         "validate",
+        "explain_drift",
         "create_entity",
         "update_entity",
     } <= names
@@ -94,3 +96,36 @@ def test_validate_tool_reports_ok(model_dir):
     srv = build_server(model_dir)
     r = _call(srv, "validate", {})
     assert r["ok"] is True
+
+
+def test_explain_drift_missing_manifest_is_error(model_dir):
+    srv = build_server(model_dir)
+    r = _call(srv, "explain_drift", {"manifest": "/nope/manifest.json"})
+    assert "error" in r
+
+
+def test_explain_drift_reports_annotated_items(model_dir, tmp_path):
+    # Build a manifest from the model, add a column (additive) + drop one (breaking),
+    # write it, and point the tool at it. Reuses the reverse tests' manifest builder.
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "reverse" / "tests"))
+    from mdl_core.repo import ModelRepo
+
+    from manifest_fixtures import manifest_from_model
+
+    repo = ModelRepo.load(model_dir)
+    raw = manifest_from_model(repo.model, "duckdb_dev")
+    node = raw["nodes"]["model.testproj.counterparty"]
+    node["columns"]["loyalty_tier"] = {"name": "loyalty_tier", "data_type": "VARCHAR"}
+    node["columns"].pop("legal_name", None)
+    man = tmp_path / "manifest.json"
+    man.write_text(json.dumps(raw))
+
+    r = _call(build_server(model_dir), "explain_drift", {"manifest": str(man)})
+    assert r["has_breaking"] is True
+    assert r["safe_count"] >= 1
+    assert r["breaking_count"] >= 1
+    # the additive column is reconcilable with an action; no breaking item is
+    assert any(i["reconcile_action"] and "loyalty_tier" in i["reconcile_action"] for i in r["items"])
+    assert all(not i["reconcilable"] for i in r["items"] if i["severity"] == "breaking")

--- a/packages/reverse/src/mdl_reverse/explain.py
+++ b/packages/reverse/src/mdl_reverse/explain.py
@@ -1,0 +1,120 @@
+"""Explain a drift report: the one structured shape every surface consumes.
+
+`mdl drift --explain`, the `explain_drift()` MCP tool, and the VS Code drift UI all
+need the same thing — the report, plus, per item, whether it is safely reconcilable
+and (if so) the concrete action reconcile would take. Rather than each surface
+re-deriving that from `DriftKind`, this module produces it once. The deterministic
+engine (`compute_drift`, severity) stays the source of truth; this only annotates.
+
+Nothing here calls an LLM. An LLM surface (chat, MCP client) grounds on this JSON;
+the CLI renders it directly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from mdl_reverse.drift import DriftItem, DriftReport, DriftSeverity
+from mdl_reverse.render import RECONCILABLE_KINDS, counts_by_severity
+
+
+def _reconcile_action(item: DriftItem) -> str | None:
+    """The concrete action `mdl drift --reconcile` would take for this item, or None
+    when it is not safely reconcilable (breaking, or a kind reconcile can't fold).
+
+    Mirrors `reconcile.reconcile` exactly — additive/cosmetic only, and only the
+    kinds it actually handles — so the explanation never promises a fix the engine
+    won't perform."""
+    if item.severity == DriftSeverity.breaking:
+        return None
+    if item.kind not in RECONCILABLE_KINDS:
+        return None
+    from mdl_reverse.drift import DriftKind
+
+    if item.kind == DriftKind.column_added:
+        base = item.payload.get("data_type") or "string"
+        return f"add attribute `{item.column}` ({base}) to `{item.model}`"
+    if item.kind == DriftKind.description_changed:
+        return f"update the definition of `{item.model}` from the warehouse description"
+    return None  # unreachable given RECONCILABLE_KINDS, but keeps the mapping explicit
+
+
+def explain_item(
+    item: DriftItem, file_for_model: Callable[[str], str | None] | None = None
+) -> dict:
+    """One drift item, annotated with its reconcile action and safety. `file_for_model`
+    (optional) resolves the model name to the YAML file the drift is about, so a UI can
+    open it without re-deriving the mapping."""
+    action = _reconcile_action(item)
+    return {
+        "severity": item.severity.value,
+        "kind": item.kind.value,
+        "model": item.model,
+        "column": item.column,
+        "detail": item.detail,
+        "payload": item.payload,
+        # True when `--reconcile` will fold this in automatically; breaking is never
+        # auto-applied and carries reconcilable=False + reconcile_action=None.
+        "reconcilable": action is not None,
+        "reconcile_action": action,
+        "file": file_for_model(item.model) if file_for_model else None,
+    }
+
+
+def explain_report(
+    report: DriftReport, file_for_model: Callable[[str], str | None] | None = None
+) -> dict:
+    """The whole report as the structured shape every surface consumes: the summary
+    counts, the breaking/reconcilable split, and every item annotated.
+
+    `safe_count` / `breaking_count` are what a UI shows as "🟡 N safe / 🔴 N breaking";
+    `reconcilable` lists the items `--reconcile` would apply, so a surface can offer a
+    one-click "reconcile safe changes" without re-deriving the set."""
+    items = [explain_item(i, file_for_model) for i in report.items]
+    reconcilable = [i for i in items if i["reconcilable"]]
+    breaking = [i for i in items if i["severity"] == DriftSeverity.breaking.value]
+    return {
+        "target": report.target,
+        "max_severity": report.max_severity.value if report.max_severity else None,
+        "has_breaking": report.has_breaking,
+        "counts": counts_by_severity(report),
+        "safe_count": len(reconcilable),
+        "breaking_count": len(breaking),
+        "items": items,
+        "reconcilable": reconcilable,
+    }
+
+
+def render_explain_text(report: DriftReport) -> str:
+    """A deterministic human narrative of the explained report — the LLM-free
+    rendering `mdl drift --explain` prints, and the fallback the chat surface uses
+    when no language model is available. Groups by severity and, per item, states the
+    concrete reconcile action or that a human must decide."""
+    ex = explain_report(report)
+    if not ex["items"]:
+        return "✅ no drift — the model matches the warehouse."
+
+    lines = [
+        f"Drift vs target {ex['target']!r}: "
+        f"🔴 {ex['breaking_count']} breaking, 🟢 {ex['safe_count']} safe to reconcile.",
+        "",
+    ]
+    for sev in (
+        DriftSeverity.breaking,
+        DriftSeverity.unmanaged,
+        DriftSeverity.additive,
+        DriftSeverity.cosmetic,
+    ):
+        group = [i for i in ex["items"] if i["severity"] == sev.value]
+        if not group:
+            continue
+        lines.append(f"[{sev.value}] ({len(group)})")
+        for i in group:
+            where = f"{i['model']}.{i['column']}" if i["column"] else i["model"]
+            lines.append(f"  - {where}: {i['detail']}")
+            if i["reconcile_action"]:
+                lines.append(f"      fix: {i['reconcile_action']}")
+            elif sev == DriftSeverity.breaking:
+                lines.append("      breaking — needs a human decision, not auto-reconciled")
+        lines.append("")
+    return "\n".join(lines).rstrip()

--- a/packages/reverse/src/mdl_reverse/reconcile.py
+++ b/packages/reverse/src/mdl_reverse/reconcile.py
@@ -46,17 +46,27 @@ def _base_for(sql_type: str | None) -> str:
     return _SQL_TO_BASE.get(sql_type.upper(), "string")
 
 
-def reconcile(repo: ModelRepo, report: DriftReport, target: str) -> ReconcileResult:
-    """Apply additive/cosmetic deltas to repo's raw nodes. Caller then saves."""
-    # Map model_name -> logical entity ULID, so we know which file to edit.
-    name_to_le: dict[str, str] = {}
+def model_name_to_ulid(repo: ModelRepo, target: str) -> dict[str, str]:
+    """Map a drift item's `model` name -> the logical entity's ULID for `target`.
+
+    A drift item names the physical/dbt model; that maps back to the logical entity
+    (via its physical table for the target, else the logical name). Shared so reconcile
+    and the explain/UI layers resolve "which entity/file is this drift about?" the same
+    way rather than each re-deriving it."""
     pt_by_logical = {
         pt.realises: pt for pt in repo.model.physical_tables.values() if pt.target == target
     }
+    name_to_le: dict[str, str] = {}
     for le in repo.model.logical_entities.values():
         pt = pt_by_logical.get(le.id)
         name = pt.name.lower() if pt else le.name
         name_to_le[name] = le.id
+    return name_to_le
+
+
+def reconcile(repo: ModelRepo, report: DriftReport, target: str) -> ReconcileResult:
+    """Apply additive/cosmetic deltas to repo's raw nodes. Caller then saves."""
+    name_to_le = model_name_to_ulid(repo, target)
 
     applied: list[str] = []
     skipped_breaking = 0

--- a/packages/reverse/tests/test_explain.py
+++ b/packages/reverse/tests/test_explain.py
@@ -1,0 +1,104 @@
+"""Tests for the explained-drift shape (mdl_reverse.explain).
+
+The shape every drift surface consumes: per item, whether --reconcile would fold it
+and the concrete action. Mirrors reconcile's safe/breaking boundary exactly."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from mdl_core.repo import ModelRepo
+from mdl_reverse.drift import compute_drift
+from mdl_reverse.explain import explain_report, render_explain_text
+from mdl_reverse.manifest import read_manifest_dict
+
+from manifest_fixtures import manifest_from_model
+
+TARGET = "duckdb_dev"
+
+
+def _report(model_dir: Path, mutate=None):
+    repo = ModelRepo.load(model_dir)
+    raw = manifest_from_model(repo.model, TARGET)
+    if mutate:
+        mutate(raw)
+    proj = read_manifest_dict(raw)
+    return compute_drift(repo.model, proj, TARGET)
+
+
+def test_zero_drift_explains_clean(model_dir: Path):
+    ex = explain_report(_report(model_dir))
+    assert ex["items"] == []
+    assert ex["has_breaking"] is False
+    assert ex["safe_count"] == 0
+    assert ex["breaking_count"] == 0
+    assert "no drift" in render_explain_text(_report(model_dir))
+
+
+def test_additive_column_is_reconcilable_with_action(model_dir: Path):
+    def add_column(raw):
+        node = raw["nodes"]["model.testproj.counterparty"]
+        node["columns"]["new_col"] = {"name": "new_col", "data_type": "VARCHAR"}
+
+    ex = explain_report(_report(model_dir, add_column))
+    added = [i for i in ex["items"] if i["column"] == "new_col"]
+    assert added, ex["items"]
+    item = added[0]
+    assert item["reconcilable"] is True
+    assert item["reconcile_action"] is not None
+    assert "new_col" in item["reconcile_action"]
+    # it shows up in the reconcilable set and the safe count
+    assert ex["safe_count"] >= 1
+    assert any(i["column"] == "new_col" for i in ex["reconcilable"])
+
+
+def test_breaking_drop_is_never_reconcilable(model_dir: Path):
+    def drop_a_column(raw):
+        node = raw["nodes"]["model.testproj.counterparty"]
+        node["columns"].pop("legal_name", None)
+
+    ex = explain_report(_report(model_dir, drop_a_column))
+    breaking = [i for i in ex["items"] if i["severity"] == "breaking"]
+    assert breaking, ex["items"]
+    for i in breaking:
+        assert i["reconcilable"] is False
+        assert i["reconcile_action"] is None
+    assert ex["has_breaking"] is True
+    assert ex["breaking_count"] == len(breaking)
+    # no breaking item leaks into the reconcilable set
+    assert all(i["severity"] != "breaking" for i in ex["reconcilable"])
+
+
+def test_explain_resolves_owning_file(model_dir: Path):
+    from mdl_reverse.reconcile import model_name_to_ulid
+
+    repo = ModelRepo.load(model_dir)
+
+    def add_column(raw):
+        node = raw["nodes"]["model.testproj.counterparty"]
+        node["columns"]["new_col"] = {"name": "new_col", "data_type": "VARCHAR"}
+
+    raw = manifest_from_model(repo.model, TARGET)
+    add_column(raw)
+    report = compute_drift(repo.model, read_manifest_dict(raw), TARGET)
+
+    name_to_le = model_name_to_ulid(repo, TARGET)
+
+    def file_for(model_name):
+        le = name_to_le.get(model_name)
+        return repo.path_for_ulid(le) if le else None
+
+    ex = explain_report(report, file_for)
+    hit = next(i for i in ex["items"] if i["column"] == "new_col")
+    assert hit["file"] is not None
+    assert hit["file"].endswith(".yaml")
+
+
+def test_narrative_groups_and_flags_human_decision(model_dir: Path):
+    def drop_a_column(raw):
+        node = raw["nodes"]["model.testproj.counterparty"]
+        node["columns"].pop("legal_name", None)
+
+    text = render_explain_text(_report(model_dir, drop_a_column))
+    assert "[breaking]" in text
+    assert "human decision" in text

--- a/uv.lock
+++ b/uv.lock
@@ -1125,6 +1125,7 @@ dependencies = [
     { name = "mcp" },
     { name = "modelith-core" },
     { name = "modelith-ontology" },
+    { name = "modelith-reverse" },
 ]
 
 [package.metadata]
@@ -1132,6 +1133,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.2,<2" },
     { name = "modelith-core", editable = "packages/core" },
     { name = "modelith-ontology", editable = "packages/ontology" },
+    { name = "modelith-reverse", editable = "packages/reverse" },
 ]
 
 [[package]]

--- a/vscode/package.json
+++ b/vscode/package.json
@@ -67,10 +67,33 @@
           {
             "name": "list",
             "description": "List the model's entities."
+          },
+          {
+            "name": "drift",
+            "description": "Explain drift vs the dbt manifest and recommend fixes. Optionally name a model."
           }
         ]
       }
     ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "modelith",
+          "title": "Modelith",
+          "icon": "$(git-compare)"
+        }
+      ]
+    },
+    "views": {
+      "modelith": [
+        {
+          "id": "modelithDrift",
+          "name": "Drift",
+          "icon": "$(git-compare)",
+          "contextualTitle": "Modelith Drift"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "modelith.validate",
@@ -82,7 +105,21 @@
       },
       {
         "command": "modelith.driftCheck",
-        "title": "Modelith: Check Drift vs dbt Manifest"
+        "title": "Modelith: Check Drift vs dbt Manifest",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "modelith.driftReconcile",
+        "title": "Modelith: Reconcile Safe Drift",
+        "icon": "$(check)"
+      },
+      {
+        "command": "modelith.driftExplain",
+        "title": "Modelith: Explain Drift (@modelith)"
+      },
+      {
+        "command": "modelith.driftFocusView",
+        "title": "Modelith: Show Drift View"
       },
       {
         "command": "modelith.lintFix",
@@ -212,6 +249,18 @@
           "command": "modelith.openPreview",
           "when": "resourceExtname == .sql || resourceExtname == .yaml",
           "group": "modelith"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "modelith.driftCheck",
+          "when": "view == modelithDrift",
+          "group": "navigation@1"
+        },
+        {
+          "command": "modelith.driftReconcile",
+          "when": "view == modelithDrift",
+          "group": "navigation@2"
         }
       ]
     }

--- a/vscode/src/chatParticipant.ts
+++ b/vscode/src/chatParticipant.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
-import { findMdl, findModelDir, runMdl } from "./mdl";
+import type { DriftItem, DriftReport } from "./driftDiagnostics";
+import { findManifestPath, findMdl, findModelDir, runMdl } from "./mdl";
 
 /** The `@modelith` chat participant, for Copilot Chat's ASK mode — where MCP tools
  * structurally cannot run (no agentic loop to invoke them from). It answers about
@@ -115,6 +116,10 @@ export function registerChatParticipant(ctx: vscode.ExtensionContext): void {
     try {
       if (request.command === "list") {
         await renderList(dir, stream);
+        return;
+      }
+      if (request.command === "drift") {
+        await driftCommand(dir, request, stream, token);
         return;
       }
 
@@ -323,4 +328,120 @@ async function renderSummary(dir: string, stream: vscode.ChatResponseStream): Pr
       "`@modelith /list`. For editing, switch Copilot Chat to **Agent mode** — the " +
       "Modelith tools (create/update entities, ontology search) run there.",
   );
+}
+
+/** `@modelith /drift [model]` — explain drift vs the dbt manifest.
+ *
+ * Runs `mdl drift --explain --format json` (the same shape the Problems panel and MCP
+ * tool consume), grounds the user's Copilot model on it (severity is authoritative —
+ * the model never re-derives it), and adds a "Reconcile safe changes" button plus a
+ * file reference per affected model. Falls back to a deterministic render when no
+ * language model is available or the drift run has no manifest. */
+async function driftCommand(
+  dir: string,
+  request: vscode.ChatRequest,
+  stream: vscode.ChatResponseStream,
+  token: vscode.CancellationToken,
+): Promise<void> {
+  const manifest = await findManifestPath();
+  if (!manifest) {
+    stream.markdown(
+      "No dbt manifest found. Run `dbt compile` / `dbt parse` (or set " +
+        "`modelith.manifestPath`), then ask again.",
+    );
+    return;
+  }
+  const bin = await findMdl(dir);
+  const r = await runMdl(
+    bin,
+    ["drift", "--manifest", manifest, "-m", ".", "--explain", "--format", "json"],
+    dir,
+  );
+  let report: DriftReport;
+  try {
+    report = JSON.parse(r.stdout) as DriftReport;
+  } catch {
+    stream.markdown(`⚠️ Could not read the drift report. ${r.stderr.trim()}`);
+    return;
+  }
+
+  const scope = request.prompt.trim().toLowerCase();
+  const items = scope
+    ? report.items.filter((i) => i.model.toLowerCase() === scope)
+    : report.items;
+
+  if (items.length === 0) {
+    stream.markdown(
+      scope
+        ? `No drift on **${scope}** vs target \`${report.target}\`.`
+        : `✅ No drift vs target \`${report.target}\` — the model matches the warehouse.`,
+    );
+    return;
+  }
+
+  const facts = JSON.stringify({ ...report, items }, null, 2);
+  const system =
+    "You are Modelith, explaining schema drift between a data model and its compiled " +
+    "dbt warehouse. Use ONLY the JSON drift facts. `severity` (breaking/additive/cosmetic) " +
+    "is authoritative — never re-derive or dispute it. For each breaking item, explain the " +
+    "impact and the recommended remediation from its `reconcile_action` or `payload`, and " +
+    "state plainly that breaking changes need a human decision (they are never " +
+    "auto-reconciled). Additive/cosmetic items are safe to reconcile. Be concise, group by " +
+    "severity, use the model's own names, and use Markdown.";
+
+  if (request.model) {
+    try {
+      const messages = [
+        vscode.LanguageModelChatMessage.User(`${system}\n\nDRIFT FACTS:\n${facts}`),
+        vscode.LanguageModelChatMessage.User(request.prompt || "Explain the drift."),
+      ];
+      const res = await request.model.sendRequest(messages, {}, token);
+      for await (const chunk of res.text) stream.markdown(chunk);
+    } catch {
+      renderDriftFallback(report, items, stream);
+    }
+  } else {
+    renderDriftFallback(report, items, stream);
+  }
+
+  // Actionable trailer: a reconcile button (safe changes only) + file references.
+  if (report.safe_count > 0) {
+    stream.button({
+      command: "modelith.driftReconcile",
+      title: `Reconcile ${report.safe_count} safe change(s)`,
+    });
+  }
+  const files = [...new Set(items.map((i) => i.file).filter((f): f is string => !!f))];
+  for (const f of files) {
+    stream.reference(vscode.Uri.file(`${dir}/${f}`));
+  }
+  if (report.breaking_count > 0) {
+    stream.markdown(
+      `\n\n_${report.breaking_count} breaking change(s) need a human decision — not auto-reconciled._`,
+    );
+  }
+}
+
+/** Deterministic drift narrative when no language model is available. */
+function renderDriftFallback(
+  report: DriftReport,
+  items: DriftItem[],
+  stream: vscode.ChatResponseStream,
+): void {
+  stream.markdown(
+    `**Drift vs \`${report.target}\`** — 🔴 ${report.breaking_count} breaking, ` +
+      `🟢 ${report.safe_count} safe to reconcile.\n\n`,
+  );
+  for (const sev of ["breaking", "additive", "cosmetic", "unmanaged"] as const) {
+    const group = items.filter((i) => i.severity === sev);
+    if (group.length === 0) continue;
+    stream.markdown(`**${sev}** (${group.length})\n`);
+    for (const i of group) {
+      const where = i.column ? `${i.model}.${i.column}` : i.model;
+      stream.markdown(`- \`${where}\` — ${i.detail}`);
+      if (i.reconcile_action) stream.markdown(` _(fix: ${i.reconcile_action})_`);
+      stream.markdown("\n");
+    }
+    stream.markdown("\n");
+  }
 }

--- a/vscode/src/driftDiagnostics.ts
+++ b/vscode/src/driftDiagnostics.ts
@@ -1,0 +1,194 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { findManifestPath, findMdl, findModelDir, runMdl } from "./mdl";
+
+/** Drift as first-class VS Code diagnostics + code actions.
+ *
+ * One `mdl drift --explain --format json` run is the single source of truth (the
+ * same shape the CLI narrative and the MCP tool consume). This module parses it into
+ * `DriftItem`s, publishes them to a DiagnosticCollection keyed by the owning model
+ * YAML file (so drift shows as squiggles + Problems entries), and offers code actions
+ * that mirror the engine's reconcile boundary: additive/cosmetic can be reconciled,
+ * breaking is only ever explained. The parsed report is cached so the Drift tree view
+ * and the `@modelith /drift` chat command reuse it without re-running drift. */
+
+export interface DriftItem {
+  severity: "breaking" | "additive" | "cosmetic" | "unmanaged";
+  kind: string;
+  model: string;
+  column: string | null;
+  detail: string;
+  payload: Record<string, unknown>;
+  reconcilable: boolean;
+  reconcile_action: string | null;
+  file: string | null;
+}
+
+export interface DriftReport {
+  target: string;
+  max_severity: string | null;
+  has_breaking: boolean;
+  counts: Record<string, number>;
+  safe_count: number;
+  breaking_count: number;
+  items: DriftItem[];
+  reconcilable: DriftItem[];
+}
+
+const SEVERITY_ORDER = ["breaking", "unmanaged", "additive", "cosmetic"] as const;
+
+function toVSCodeSeverity(sev: DriftItem["severity"]): vscode.DiagnosticSeverity {
+  switch (sev) {
+    case "breaking":
+      return vscode.DiagnosticSeverity.Error;
+    case "additive":
+    case "unmanaged":
+      return vscode.DiagnosticSeverity.Warning;
+    default:
+      return vscode.DiagnosticSeverity.Information;
+  }
+}
+
+/** Manages the drift diagnostics + the cached last report. A single instance is
+ * created in activate() and shared with the tree view and the chat command. */
+export class DriftManager {
+  private readonly collection: vscode.DiagnosticCollection;
+  private readonly emitter = new vscode.EventEmitter<DriftReport | undefined>();
+  /** Fires whenever a drift check completes (or is cleared); the tree view listens. */
+  readonly onDidChange = this.emitter.event;
+  private lastReport: DriftReport | undefined;
+
+  constructor(private readonly out: vscode.OutputChannel) {
+    this.collection = vscode.languages.createDiagnosticCollection("modelith-drift");
+  }
+
+  get report(): DriftReport | undefined {
+    return this.lastReport;
+  }
+
+  dispose(): void {
+    this.collection.dispose();
+    this.emitter.dispose();
+  }
+
+  /** Run drift and publish diagnostics. Returns the report, or undefined when no
+   * manifest is found (the caller surfaces the "run dbt compile" hint). */
+  async check(dir: string): Promise<DriftReport | undefined> {
+    const manifest = await findManifestPath();
+    if (!manifest) {
+      void vscode.window.showWarningMessage(
+        "Modelith: no manifest.json found — run `dbt parse`/`dbt compile` (or set modelith.manifestPath).",
+      );
+      return undefined;
+    }
+    const bin = await findMdl(dir);
+    const r = await runMdl(
+      bin,
+      ["drift", "--manifest", manifest, "-m", ".", "--explain", "--format", "json"],
+      dir,
+    );
+    if (r.code !== 0 && !r.stdout.trim()) {
+      this.out.appendLine(`[drift] failed: ${r.stderr}`);
+      void vscode.window.showErrorMessage(`Modelith drift: ${r.stderr.trim() || "failed"}`);
+      return undefined;
+    }
+    let report: DriftReport;
+    try {
+      report = JSON.parse(r.stdout) as DriftReport;
+    } catch {
+      this.out.appendLine(`[drift] unparseable output: ${r.stdout}\n${r.stderr}`);
+      void vscode.window.showErrorMessage("Modelith drift: could not parse the report.");
+      return undefined;
+    }
+    this.publish(dir, report);
+    return report;
+  }
+
+  /** Publish the report's items as diagnostics grouped by file, and cache it. */
+  private publish(dir: string, report: DriftReport): void {
+    this.collection.clear();
+    const byFile = new Map<string, vscode.Diagnostic[]>();
+    for (const item of report.items) {
+      // Items resolve to their owning model YAML; those that don't (e.g. a removed
+      // model) attach to mdl-project.yaml so they're never silently dropped.
+      const rel = item.file ?? "mdl-project.yaml";
+      const abs = path.join(dir, rel);
+      const diag = new vscode.Diagnostic(
+        new vscode.Range(0, 0, 0, 0),
+        item.column ? `${item.detail} (column: ${item.column})` : item.detail,
+        toVSCodeSeverity(item.severity),
+      );
+      diag.source = "modelith-drift";
+      diag.code = item.kind;
+      const list = byFile.get(abs) ?? [];
+      list.push(diag);
+      byFile.set(abs, list);
+    }
+    for (const [abs, diags] of byFile) {
+      this.collection.set(vscode.Uri.file(abs), diags);
+    }
+    this.lastReport = report;
+    this.emitter.fire(report);
+  }
+
+  clear(): void {
+    this.collection.clear();
+    this.lastReport = undefined;
+    this.emitter.fire(undefined);
+  }
+}
+
+/** Code actions on a drift diagnostic: reconcile a safe change, or explain a breaking
+ * one. Mirrors the engine — never offers auto-apply for breaking drift. */
+export class DriftCodeActionProvider implements vscode.CodeActionProvider {
+  static readonly kinds = [vscode.CodeActionKind.QuickFix];
+
+  constructor(private readonly manager: DriftManager) {}
+
+  provideCodeActions(
+    document: vscode.TextDocument,
+    _range: vscode.Range | vscode.Selection,
+    context: vscode.CodeActionContext,
+  ): vscode.CodeAction[] {
+    const report = this.manager.report;
+    if (!report) return [];
+    const actions: vscode.CodeAction[] = [];
+    let offeredReconcileAll = false;
+    for (const diag of context.diagnostics) {
+      if (diag.source !== "modelith-drift") continue;
+      // Match the diagnostic back to a report item by kind + this file.
+      const item = report.items.find(
+        (i) => i.kind === diag.code && document.fileName.endsWith(i.file ?? "mdl-project.yaml"),
+      );
+      if (!item) continue;
+      if (item.reconcilable && !offeredReconcileAll) {
+        // Reconcile is whole-report (drift --reconcile folds every safe change), so
+        // one action per file is enough; label it for clarity.
+        const fix = new vscode.CodeAction(
+          "Modelith: Reconcile safe drift into the model",
+          vscode.CodeActionKind.QuickFix,
+        );
+        fix.command = { command: "modelith.driftReconcile", title: "Reconcile safe drift" };
+        fix.diagnostics = [diag];
+        actions.push(fix);
+        offeredReconcileAll = true;
+      } else if (item.severity === "breaking") {
+        const explain = new vscode.CodeAction(
+          "Modelith: Explain this breaking drift (@modelith)",
+          vscode.CodeActionKind.QuickFix,
+        );
+        explain.command = {
+          command: "modelith.driftExplain",
+          title: "Explain drift",
+          arguments: [item.model],
+        };
+        explain.diagnostics = [diag];
+        actions.push(explain);
+      }
+    }
+    return actions;
+  }
+}
+
+export { SEVERITY_ORDER, toVSCodeSeverity };
+export { findModelDir };

--- a/vscode/src/driftView.ts
+++ b/vscode/src/driftView.ts
@@ -1,0 +1,97 @@
+import * as path from "node:path";
+import * as vscode from "vscode";
+import { type DriftItem, type DriftManager, SEVERITY_ORDER } from "./driftDiagnostics";
+
+/** The Drift tree view: findings grouped Breaking / Additive / Cosmetic, each
+ * clickable to open the owning model file. Reads the cached report from the shared
+ * DriftManager (no extra drift run) and refreshes when it changes. */
+
+type Node = GroupNode | ItemNode;
+
+interface GroupNode {
+  kind: "group";
+  severity: DriftItem["severity"];
+  items: DriftItem[];
+}
+
+interface ItemNode {
+  kind: "item";
+  item: DriftItem;
+}
+
+const SEVERITY_LABEL: Record<DriftItem["severity"], string> = {
+  breaking: "Breaking",
+  unmanaged: "Unmanaged",
+  additive: "Additive",
+  cosmetic: "Cosmetic",
+};
+
+const SEVERITY_ICON: Record<DriftItem["severity"], vscode.ThemeIcon> = {
+  breaking: new vscode.ThemeIcon("error", new vscode.ThemeColor("errorForeground")),
+  unmanaged: new vscode.ThemeIcon("warning"),
+  additive: new vscode.ThemeIcon("diff-added"),
+  cosmetic: new vscode.ThemeIcon("info"),
+};
+
+export class DriftTreeProvider implements vscode.TreeDataProvider<Node> {
+  private readonly emitter = new vscode.EventEmitter<Node | undefined>();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  constructor(
+    private readonly manager: DriftManager,
+    private readonly modelDir: () => Promise<string | undefined>,
+  ) {
+    manager.onDidChange(() => this.emitter.fire(undefined));
+  }
+
+  getTreeItem(node: Node): vscode.TreeItem {
+    if (node.kind === "group") {
+      const ti = new vscode.TreeItem(
+        `${SEVERITY_LABEL[node.severity]} (${node.items.length})`,
+        vscode.TreeItemCollapsibleState.Expanded,
+      );
+      ti.iconPath = SEVERITY_ICON[node.severity];
+      ti.contextValue = `driftGroup:${node.severity}`;
+      return ti;
+    }
+    const item = node.item;
+    const where = item.column ? `${item.model}.${item.column}` : item.model;
+    const ti = new vscode.TreeItem(where, vscode.TreeItemCollapsibleState.None);
+    ti.description = item.kind.replace(/_/g, " ");
+    ti.tooltip = item.reconcile_action
+      ? `${item.detail}\n\nFix: ${item.reconcile_action}`
+      : item.detail;
+    ti.iconPath = SEVERITY_ICON[item.severity];
+    // reconcilable items get a context value so a per-item "Reconcile" inline action
+    // can be contributed in package.json; breaking items get "explain".
+    ti.contextValue = item.reconcilable ? "driftItem:reconcilable" : "driftItem:breaking";
+    return ti;
+  }
+
+  async getChildren(node?: Node): Promise<Node[]> {
+    const report = this.manager.report;
+    if (!report) return [];
+    if (!node) {
+      // top level: one group per severity that has items, in severity order
+      return SEVERITY_ORDER.filter((sev) => report.items.some((i) => i.severity === sev)).map(
+        (severity) => ({
+          kind: "group" as const,
+          severity,
+          items: report.items.filter((i) => i.severity === severity),
+        }),
+      );
+    }
+    if (node.kind === "group") {
+      return node.items.map((item) => ({ kind: "item" as const, item }));
+    }
+    return [];
+  }
+
+  /** Open the model file an item points at (used by the item's command). */
+  async reveal(item: DriftItem): Promise<void> {
+    const dir = await this.modelDir();
+    if (!dir || !item.file) return;
+    const uri = vscode.Uri.file(path.join(dir, item.file));
+    await vscode.window.showTextDocument(uri, { preview: true });
+  }
+}

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -3,6 +3,8 @@ import * as vscode from "vscode";
 import type { LanguageClient } from "vscode-languageclient/node";
 import { CanvasManager } from "./canvasPanel";
 import { registerChatParticipant } from "./chatParticipant";
+import { DriftCodeActionProvider, DriftManager } from "./driftDiagnostics";
+import { DriftTreeProvider } from "./driftView";
 import { executeLspCommand, startLsp } from "./lspClient";
 import { registerMcpProvider } from "./mcpProvider";
 import {
@@ -38,6 +40,41 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
   // hosts that lack their API, so a failure here never blocks the LSP or canvas.
   registerMcpProvider(ctx);
   registerChatParticipant(ctx);
+
+  // Drift surfacing: one DriftManager owns the drift diagnostics + the last report;
+  // the tree view and code-action provider read from it. A status-bar item reflects
+  // the drift state and reveals the view.
+  const drift = new DriftManager(out);
+  ctx.subscriptions.push({ dispose: () => drift.dispose() });
+  const driftStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 89);
+  driftStatus.command = "modelith.driftFocusView";
+  ctx.subscriptions.push(driftStatus);
+  const driftTree = new DriftTreeProvider(drift, findModelDir);
+  ctx.subscriptions.push(
+    vscode.window.registerTreeDataProvider("modelithDrift", driftTree),
+    vscode.languages.registerCodeActionsProvider(
+      [
+        { scheme: "file", language: "yaml" },
+        { scheme: "file", pattern: "**/*.yaml" },
+      ],
+      new DriftCodeActionProvider(drift),
+      { providedCodeActionKinds: DriftCodeActionProvider.kinds },
+    ),
+    drift.onDidChange((report) => {
+      if (!report || report.items.length === 0) {
+        driftStatus.text = "$(check) Drift: clean";
+        driftStatus.tooltip = "No drift vs the dbt manifest";
+      } else {
+        const b = report.breaking_count;
+        const safe = report.safe_count;
+        driftStatus.text = b
+          ? `$(error) Drift: ${b} breaking`
+          : `$(warning) Drift: ${safe} safe`;
+        driftStatus.tooltip = `${b} breaking, ${safe} safe to reconcile — click to view`;
+      }
+      driftStatus.show();
+    }),
+  );
 
   // After a window reload VS Code restores our webview panels, but the `mdl serve`
   // child died with the old extension host, so the restored iframe points at a
@@ -269,29 +306,65 @@ export async function activate(ctx: vscode.ExtensionContext): Promise<void> {
 
   cmd("modelith.driftCheck", () =>
     withModelDir(async (dir) => {
-      const manifest = await findManifestPath();
-      if (!manifest) {
-        void vscode.window.showWarningMessage(
-          "Modelith: no manifest.json found — run `dbt parse` (or set modelith.manifestPath).",
+      // Populate the Problems panel + the Drift tree + the status bar from one
+      // `mdl drift --explain --format json` run (in DriftManager), replacing the old
+      // text-dump-to-output behaviour.
+      const report = await drift.check(dir);
+      if (!report) return;
+      if (report.items.length === 0) {
+        void vscode.window.setStatusBarMessage("Modelith: no drift ✓", 4000);
+      } else {
+        void vscode.commands.executeCommand("modelithDrift.focus");
+      }
+    }),
+  );
+
+  cmd("modelith.driftReconcile", () =>
+    withModelDir(async (dir) => {
+      const report = drift.report;
+      const safe = report?.safe_count ?? 0;
+      if (safe === 0) {
+        void vscode.window.showInformationMessage(
+          "Modelith: no safe (additive/cosmetic) drift to reconcile. Breaking drift needs a human decision.",
         );
         return;
       }
+      const ok = await vscode.window.showWarningMessage(
+        `Reconcile ${safe} safe drift change(s) into the model? Breaking changes are left untouched.`,
+        { modal: true },
+        "Reconcile",
+      );
+      if (ok !== "Reconcile") return;
+      const manifest = await findManifestPath();
+      if (!manifest) return;
       const bin = await findMdl(dir);
-      const r = await runMdl(bin, ["drift", "--manifest", manifest, "-m", ".", "--check"], dir);
+      const r = await runMdl(
+        bin,
+        ["drift", "--manifest", manifest, "-m", ".", "--reconcile"],
+        dir,
+      );
       out.appendLine(r.stdout + r.stderr);
-      if (r.code === 2) {
+      if (r.code === 0 || r.code === 2) {
+        void vscode.window.setStatusBarMessage("Modelith: reconciled safe drift ✓", 4000);
+        await drift.check(dir); // refresh diagnostics + tree from the new state
+      } else {
         void vscode.window
-          .showErrorMessage("Modelith: BREAKING drift vs dbt manifest.", "Show Report")
+          .showErrorMessage("Modelith: reconcile failed.", "Show Output")
           .then((a) => a && out.show());
-      } else if (r.code === 0) {
-        const clean = r.stdout.includes("no drift detected");
-        void vscode.window.setStatusBarMessage(
-          clean ? "Modelith: no drift ✓" : "Modelith: non-breaking drift (see output)",
-          5000,
-        );
-        if (!clean) out.show(true);
       }
     }),
+  );
+
+  cmd("modelith.driftExplain", (...args: unknown[]) => {
+    // Hand off to the @modelith chat participant, optionally scoped to one model.
+    const model = typeof args[0] === "string" ? ` ${args[0]}` : "";
+    void vscode.commands.executeCommand("workbench.action.chat.open", {
+      query: `@modelith /drift${model}`,
+    });
+  });
+
+  cmd("modelith.driftFocusView", () =>
+    vscode.commands.executeCommand("modelithDrift.focus"),
   );
 
   cmd("modelith.lintFix", () =>


### PR DESCRIPTION
Turns the drift engine's structured report into first-class VS Code surfaces and an MCP tool, all consuming one explained shape so no surface re-derives severity or the reconcile boundary.

Engine (Python):
- mdl_reverse/explain.py: explain_report() annotates each drift item with whether --reconcile would fold it (safe) and the concrete action; breaking is never reconcilable. render_explain_text() is the deterministic narrative. Extracted model_name_to_ulid() from reconcile so the file resolver is shared, not duplicated.
- mdl drift --explain [--format json]: the structured shape (with owning YAML file per item) that the CLI, MCP tool and VS Code all consume.
- MCP explain_drift() tool: same report for an agent; errors cleanly with no manifest.

VS Code:
- driftDiagnostics.ts: DriftManager runs `drift --explain --format json` once and publishes items to a DiagnosticCollection keyed by the owning file (breaking=Error, additive=Warning, cosmetic=Info); caches the report for the tree + chat. DriftCodeActionProvider offers reconcile on safe items, explain on breaking.
- driftView.ts: a Drift tree grouped by severity, click-to-open.
- Commands: driftCheck (upgraded to populate Problems + tree + status bar), driftReconcile (confirm, safe-only), driftExplain (→ @modelith /drift), driftFocusView; a status-bar item reflecting drift state.
- @modelith /drift [model]: grounded explainer with a Reconcile button + file references, deterministic fallback when no model.

Safety mirrors reconcile() everywhere: additive/cosmetic reconcilable with confirmation, breaking explained only.

Tested: 603 pytest pass (+7: explain + MCP drift tests), ruff clean, extension tsc + esbuild clean. Verified mdl drift --explain and the MCP tool end-to-end against a drifted demo manifest (1 breaking + 1 additive, resolving to price.yaml).

<!-- Thanks for contributing to Modelith. Keep this short. -->

## What this changes

<!-- One or two sentences on what and why. Link the issue it closes: Closes #123 -->

## How it was tested

<!-- The commands you ran. `uv run pytest` and `uv run ruff check packages/` at minimum. -->

## Checklist

- [ ] Tests pass locally (`uv run pytest`)
- [ ] Lint passes (`uv run ruff check packages/`)
- [ ] Docs or the README updated if behavior changed
- [ ] The change fits the git-native, stateless design (git stays the source of truth)
